### PR TITLE
Be PSR-11 v2/3 compatible

### DIFF
--- a/src/Container.php
+++ b/src/Container.php
@@ -19,7 +19,7 @@ final class Container implements ContainerInterface
         return new self($servicesById);
     }
 
-    public function get($id)
+    public function get($id): mixed
     {
         if (! $this->has($id)) {
             throw ServiceNotFound::byId($id);
@@ -28,7 +28,7 @@ final class Container implements ContainerInterface
         return $this->servicesById[$id];
     }
 
-    public function has($id)
+    public function has($id): bool
     {
         return isset($this->servicesById[$id]);
     }


### PR DESCRIPTION
Running composer install today brings down psr/container v3, which has both param and return types.  This adds return types to avoid it breaking entirely.  Adding param types is optional, but recommended.  I leave that to the author.

Though really, the package should also depend on psr/container directly if it's going to implement it.